### PR TITLE
Update dtc-lexer.lex.c_shipped

### DIFF
--- a/linux-4.14.90-dev/linux-4.14.90/scripts/dtc/dtc-lexer.lex.c_shipped
+++ b/linux-4.14.90-dev/linux-4.14.90/scripts/dtc/dtc-lexer.lex.c_shipped
@@ -631,7 +631,7 @@ char *yytext;
 #include "srcpos.h"
 #include "dtc-parser.tab.h"
 
-YYLTYPE yylloc;
+extern YYLTYPE yylloc;
 extern bool treesource_error;
 
 /* CAUTION: this will stop working if we ever use yyless() or yyunput() */


### PR DESCRIPTION
$ git diff
diff --git a/scripts/dtc/dtc-lexer.lex.c_shipped b/scripts/dtc/dtc-lexer.lex.c_shipped index 2d30f41778b..d0eb405cb81 100644
--- a/scripts/dtc/dtc-lexer.lex.c_shipped
+++ b/scripts/dtc/dtc-lexer.lex.c_shipped
@@ -637,7 +637,7 @@ char *yytext;
 #include "srcpos.h"
 #include "dtc-parser.tab.h"
 
-YYLTYPE yylloc;
+extern YYLTYPE yylloc;
 
 /* CAUTION: this will stop working if we ever use yyless() or yyunput() */
 #define        YY_USER_ACTION \